### PR TITLE
Fix unsafe error.message access

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -83,6 +83,23 @@ describe("TimberlogsClient", () => {
       expect((client as any).queue[0].errorStack).toBeDefined();
     });
 
+    it("handles Error objects with undefined message", () => {
+      const client = createTimberlogs({
+        source: "test-app",
+        environment: "production",
+      });
+
+      const error = new Error();
+      (error as any).message = undefined;
+      client.error("Error occurred", error);
+
+      expect((client as any).queue[0]).toMatchObject({
+        level: "error",
+        message: "Error occurred",
+        data: { message: "Unknown error" },
+      });
+    });
+
     it("queues error logs with data object", () => {
       const client = createTimberlogs({
         source: "test-app",

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,7 +76,7 @@ export class Flow {
         message,
         errorName: error.name,
         errorStack: error.stack,
-        data: { message: error.message },
+        data: { message: error.message ?? "Unknown error" },
         tags: options?.tags,
         flowId: this.id,
         stepIndex: step,
@@ -265,7 +265,7 @@ export class TimberlogsClient {
         message,
         errorName: error.name,
         errorStack: error.stack,
-        data: { message: error.message },
+        data: { message: error.message ?? "Unknown error" },
         tags: options?.tags,
       });
     }


### PR DESCRIPTION
## Summary
- Add nullish coalescing fallback (`?? "Unknown error"`) to `error.message` in `Flow.error()` and `TimberlogsClient.error()`
- Add test for Error objects with undefined message

## Test plan
- [x] All 31 tests pass
- [x] New test verifies fallback behavior

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to gracefully manage cases where error messages are missing or undefined, providing a fallback message.

* **Tests**
  * Added test coverage for error handling scenarios with missing or undefined message properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->