### PR TITLE
Add flowId and stepIndex to README LogEntry type

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ interface LogEntry {
   errorName?: string;
   errorStack?: string;
   tags?: string[];
+  flowId?: string;
+  stepIndex?: number;
 }
 ```
 


### PR DESCRIPTION
## Summary
- Add missing `flowId` and `stepIndex` fields to the LogEntry type definition in README

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional flow tracking and step indexing fields to enhance log organization and correlation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->