### PR TITLE
Add dataset and timestamp field support

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -349,6 +349,40 @@ describe("TimberlogsClient", () => {
     });
   });
 
+  describe("dataset and timestamp", () => {
+    it("includes config-level dataset in logs", () => {
+      const client = createTimberlogs({
+        source: "test-app",
+        environment: "production",
+        dataset: "analytics",
+      });
+
+      client.info("Test message");
+      expect((client as any).queue[0].dataset).toBe("analytics");
+    });
+
+    it("allows entry-level dataset to override config", () => {
+      const client = createTimberlogs({
+        source: "test-app",
+        environment: "production",
+        dataset: "default",
+      });
+
+      client.log({ level: "info", message: "Test", dataset: "custom" });
+      expect((client as any).queue[0].dataset).toBe("custom");
+    });
+
+    it("includes timestamp in log entry", () => {
+      const client = createTimberlogs({
+        source: "test-app",
+        environment: "production",
+      });
+
+      client.log({ level: "info", message: "Test", timestamp: "2025-01-01T00:00:00Z" });
+      expect((client as any).queue[0].timestamp).toBe("2025-01-01T00:00:00Z");
+    });
+  });
+
   describe("config defaults", () => {
     it("uses default config values", () => {
       const client = createTimberlogs({

--- a/src/client.ts
+++ b/src/client.ts
@@ -125,6 +125,7 @@ export class TimberlogsClient {
     version?: string;
     userId?: string;
     sessionId?: string;
+    dataset?: string;
     onError?: (error: Error) => void;
     retry: Required<NonNullable<TimberlogsConfig["retry"]>>;
   };
@@ -142,6 +143,7 @@ export class TimberlogsClient {
       version: config.version,
       userId: config.userId,
       sessionId: config.sessionId,
+      dataset: config.dataset,
       batchSize: config.batchSize ?? 10,
       flushInterval: config.flushInterval ?? 5000,
       minLevel: config.minLevel ?? "debug",
@@ -295,6 +297,8 @@ export class TimberlogsClient {
       tags: entry.tags,
       flowId: entry.flowId,
       stepIndex: entry.stepIndex,
+      dataset: entry.dataset ?? this.config.dataset,
+      timestamp: entry.timestamp,
     };
 
     this.queue.push(logArgs);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,8 @@ export interface LogEntry {
   tags?: string[];
   flowId?: string;
   stepIndex?: number;
+  dataset?: string;
+  timestamp?: string;
 }
 
 export interface TimberlogsConfig {
@@ -28,6 +30,8 @@ export interface TimberlogsConfig {
   userId?: string;
   /** Default session ID for logs */
   sessionId?: string;
+  /** Default dataset for log routing */
+  dataset?: string;
   /** Number of logs to batch before sending (default: 10) */
   batchSize?: number;
   /** Interval in ms to flush logs (default: 5000) */
@@ -60,6 +64,8 @@ export interface CreateLogArgs {
   tags?: string[];
   flowId?: string;
   stepIndex?: number;
+  dataset?: string;
+  timestamp?: string;
 }
 
 export interface BatchLogArgs {


### PR DESCRIPTION
## Summary
- Add `dataset` to `TimberlogsConfig` as config-level default
- Add `dataset` and `timestamp` to `LogEntry` and `CreateLogArgs`
- Entry-level dataset overrides config-level default
- Add 3 tests for new fields

## Test plan
- [x] All 34 tests pass

Closes #4