### PR TITLE
Add ipAddress and country field support

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -383,6 +383,19 @@ describe("TimberlogsClient", () => {
     });
   });
 
+  describe("ipAddress and country", () => {
+    it("includes ipAddress and country in log entry", () => {
+      const client = createTimberlogs({
+        source: "test-app",
+        environment: "production",
+      });
+
+      client.log({ level: "info", message: "Test", ipAddress: "1.2.3.4", country: "US" });
+      expect((client as any).queue[0].ipAddress).toBe("1.2.3.4");
+      expect((client as any).queue[0].country).toBe("US");
+    });
+  });
+
   describe("config defaults", () => {
     it("uses default config values", () => {
       const client = createTimberlogs({

--- a/src/client.ts
+++ b/src/client.ts
@@ -343,6 +343,8 @@ export class TimberlogsClient {
       stepIndex: entry.stepIndex,
       dataset: entry.dataset ?? this.config.dataset,
       timestamp: entry.timestamp,
+      ipAddress: entry.ipAddress,
+      country: entry.country,
     };
 
     this.queue.push(logArgs);

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,8 @@ export interface LogEntry {
   stepIndex?: number;
   dataset?: string;
   timestamp?: string;
+  ipAddress?: string;
+  country?: string;
 }
 
 export interface TimberlogsConfig {
@@ -66,6 +68,8 @@ export interface CreateLogArgs {
   stepIndex?: number;
   dataset?: string;
   timestamp?: string;
+  ipAddress?: string;
+  country?: string;
 }
 
 export interface BatchLogArgs {


### PR DESCRIPTION
## Summary
- Add optional `ipAddress` and `country` fields to `LogEntry` and `CreateLogArgs`
- Wire through in `log()` method
- Add test for new fields

## Test plan
- [x] All 45 tests pass

Closes #7