### PR TITLE
Document that flow() requires API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ logger
 
 ### Flow Tracking
 
-Track related logs across multi-step processes:
+Track related logs across multi-step processes. **Note:** Flow tracking requires an `apiKey` to be configured, as flow IDs are generated server-side.
 
 ```typescript
 // Create a flow (async operation)


### PR DESCRIPTION
## Summary
- Add note to README Flow Tracking section that `apiKey` must be configured

Closes #8