### PR TITLE
Add raw format ingest support

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -748,6 +748,25 @@ describe("TimberlogsClient", () => {
     });
   });
 
+  describe("ingestRaw", () => {
+    it("throws without apiKey", async () => {
+      const client = new TimberlogsClient({
+        source: "test",
+        environment: "development",
+      });
+      await expect(client.ingestRaw("data", "csv")).rejects.toThrow("apiKey");
+    });
+
+    it("throws on invalid format", async () => {
+      const client = new TimberlogsClient({
+        source: "test",
+        environment: "development",
+        apiKey: "tb_test_key",
+      });
+      await expect(client.ingestRaw("data", "invalid" as any)).rejects.toThrow("Unsupported format");
+    });
+  });
+
   describe("flush timer", () => {
     beforeEach(() => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,6 @@ export type {
   TimberlogsConfig,
   CreateLogArgs,
   BatchLogArgs,
+  FormatName,
+  IngestRawOptions,
 } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,3 +76,12 @@ export interface BatchLogArgs {
   apiKey?: string;
   logs: Omit<CreateLogArgs, "apiKey">[];
 }
+
+export type FormatName = "json" | "jsonl" | "syslog" | "text" | "csv" | "obl";
+
+export interface IngestRawOptions {
+  source?: string;
+  environment?: Environment;
+  level?: LogLevel;
+  dataset?: string;
+}


### PR DESCRIPTION
## Summary
- Add `ingestRaw()` method for sending pre-formatted log data directly to the ingest endpoint
- Supports all 6 formats: JSON, JSONL, syslog, text, CSV, OBL
- Uses `?format=` query param and correct Content-Type headers
- Optional query params for source/environment/level/dataset defaults

Closes #20

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all tests passing
- [ ] Manual test with live endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced raw data ingestion with support for multiple formats: JSON, JSONL, Syslog, text, CSV, and OBL
  * Per-request configuration options for source, environment, log level, and dataset
  * Automatic retry logic with exponential backoff to improve ingestion reliability
  * Input validation for authentication and format support

* **Tests**
  * Added tests for the new raw data ingestion feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->