### PR TITLE
Update support email to support@timberlogs.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ interface LogEntry {
 
 ## Support
 
-Questions or feedback? Email us at [timberlogs@proton.me](mailto:timberlogs@proton.me)
+Questions or feedback? Email us at [support@timberlogs.dev](mailto:support@timberlogs.dev)
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replace `timberlogs@proton.me` with `support@timberlogs.dev` in README

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support contact email to provide customers with the correct channel for assistance and inquiries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->