### PR TITLE
Fix v1.4.2 lockfile for CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,29 @@
         "vitest": "^4.1.9"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",


### PR DESCRIPTION
Follow-up to #25 for the v1.4.2 release.

## Summary
- Add missing optional `@emnapi/core` and `@emnapi/runtime` peer package records to `package-lock.json`.
- Fix Linux runner `npm ci` failure from the first v1.4.2 publish workflow attempt.
- Keep the dependency update reproducible across GitHub Actions while leaving `package.json` unchanged.

## Test plan
- `npm ci` - passed; 0 vulnerabilities
- `npm test` - passed; Vitest v4.1.9, 50 tests
- `npm run build` - passed; generated ESM and DTS output
- `npm audit` - passed; 0 vulnerabilities
- `npm pack --dry-run` - passed; package includes README.md, package.json, dist/index.js, dist/index.js.map, and dist/index.d.ts
- ESM import smoke check - passed; exports `Flow,TimberlogsClient,createTimberlogs`
